### PR TITLE
Fix disabled <<-EOS.undent

### DIFF
--- a/Formula/luarocks.rb
+++ b/Formula/luarocks.rb
@@ -27,7 +27,7 @@ class Luarocks < Formula
     system "make install"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Rocks will be installed to: #{HOMEBREW_PREFIX}/opt/kong
     EOS
   end


### PR DESCRIPTION
A few other homebrew libraries have done the same fix or seen the same error:

https://github.com/chezou/homebrew-cloudera/pull/7
https://github.com/Homebrew/brew/issues/3738