### PR TITLE
chore(*) homebrew upgraded for Kong 1.0.0

### DIFF
--- a/Formula/kong.rb
+++ b/Formula/kong.rb
@@ -1,28 +1,34 @@
 class Kong < Formula
-  homepage "https://docs.konghq.com"
   desc "Open source Microservices and API Gateway"
+  homepage "https://docs.konghq.com"
 
   stable do
-    url "https://bintray.com/kong/kong-community-edition-src/download_file?file_path=dists%2Fkong-community-edition-0.14.1.tar.gz"
-    sha256 "945a90568838ffb7ee89e6816576a26aae0e860b5ff0a4c396f4299062eb0001"
+    url "https://bintray.com/kong/kong-community-edition-src/download_file?file_path=dists%2Fkong-community-edition-1.0.0.tar.gz"
+    sha256 "34be0f85dfe0cd058ebfe37ae0168f516e6fe68bdfd4a3a113ac28c927efe33f"
   end
-
-  #devel do
-  # url "https://github.com/Kong/kong.git", :tag => "0.13.0rc2"
-  #end
 
   head do
     url "https://github.com/Kong/kong.git", :branch => "next"
   end
 
+  depends_on "kong/kong/luarocks"
+  depends_on "kong/kong/openresty"
+  depends_on "openssl@1.1"
+
   patch :DATA
 
-  depends_on "openssl"
-  depends_on "kong/kong/openresty"
-  depends_on "kong/kong/luarocks"
-
   def install
-    system "luarocks-5.1 --tree=#{prefix} make CRYPTO_DIR=#{Formula['openssl'].opt_prefix} OPENSSL_DIR=#{Formula['openssl'].opt_prefix}"
+    luarocks_prefix = Formula["kong/kong/luarocks"].prefix
+    openresty_prefix = Formula["kong/kong/openresty"].prefix
+    openssl_prefix = Formula["openssl@1.1"].prefix
+
+    system "#{luarocks_prefix}/bin/luarocks",
+           "--tree=#{prefix}",
+           "--lua-dir=#{openresty_prefix}/luajit",
+           "make",
+           "CRYPTO_DIR=#{openssl_prefix}",
+           "OPENSSL_DIR=#{openssl_prefix}"
+
     bin.install "bin/kong"
   end
 end

--- a/Formula/luarocks.rb
+++ b/Formula/luarocks.rb
@@ -1,23 +1,24 @@
 class Luarocks < Formula
+  desc "Package manager for the Lua programming language"
   homepage "https://luarocks.org"
-  url "https://luarocks.org/releases/luarocks-2.4.2.tar.gz"
-  sha256 "0e1ec34583e1b265e0fbafb64c8bd348705ad403fe85967fd05d3a659f74d2e5"
-  head "https://github.com/keplerproject/luarocks.git"
-
-  patch :DATA
+  url "https://luarocks.org/releases/luarocks-3.0.4.tar.gz"
+  sha256 "1236a307ca5c556c4fed9fdbd35a7e0e80ccf063024becc8c3bf212f37ff0edf"
+  head "https://github.com/luarocks/luarocks.git"
 
   depends_on "kong/kong/openresty"
 
+  patch :DATA
+
   def install
-    openresty = Formula["kong/kong/openresty"]
+    openresty_prefix = Formula["kong/kong/openresty"].prefix
 
     # Install to the Cellar, but the tree to install modules is in HOMEBREW_PREFIX/opt/kong
     args = [
       "--prefix=#{prefix}",
       "--rocks-tree=#{HOMEBREW_PREFIX}/opt/kong",
       "--sysconfdir=#{prefix}/etc",
-      "--with-lua=#{openresty.prefix}/luajit",
-      "--with-lua-include=#{openresty.prefix}/luajit/include/luajit-2.1",
+      "--with-lua=#{openresty_prefix}/luajit",
+      "--with-lua-include=#{openresty_prefix}/luajit/include/luajit-2.1",
       "--lua-suffix=jit"
     ]
 
@@ -35,14 +36,14 @@ end
 # Do not attempt to create the rocks tree prefix directory,
 # since /usr/local/opt/kong lies outside of our sandbox.
 __END__
-diff -u a/luarocks-2.4.2/Makefile b/luarocks-2.4.2/Makefile
---- luarocks-2.4.2/Makefile	2016-11-30 04:49:34.000000000 -0800
-+++ luarocks-2.4.2-new/Makefile	2017-08-03 14:54:45.000000000 -0700
-@@ -133,7 +133,6 @@
- 	cp src/luarocks/site_config.lua "$(DESTDIR)$(LUADIR)/luarocks"
- 
- write_sysconfig:
--	mkdir -p "$(DESTDIR)$(ROCKS_TREE)"
- 	if [ ! -f "$(DESTDIR)$(CONFIG_FILE)" ] ;\
- 	then \
- 	   mkdir -p `dirname "$(DESTDIR)$(CONFIG_FILE)"` ;\
+diff -u a/luarocks-3.0.4/GNUmakefile b/luarocks-3.0.4/GNUmakefile
+--- luarocks-3.0.4/GNUmakefile	2018-10-30 19:31:39.000000000 +0200
++++ luarocks-3.0.4-new/GNUmakefile	2018-12-19 02:20:03.000000000 +0200
+@@ -146,7 +146,6 @@
+ # ----------------------------------------
+
+ bootstrap: luarocks $(DESTDIR)$(luarocksconfdir)/config-$(LUA_VERSION).lua
+-	./luarocks make --tree="$(DESTDIR)$(rocks_tree)"
+
+ # ----------------------------------------
+ # Windows binary build

--- a/Formula/openresty.rb
+++ b/Formula/openresty.rb
@@ -1,4 +1,5 @@
 class Openresty < Formula
+  desc "Scalable Web Platform by Extending Nginx with Lua"
   homepage "https://openresty.org/"
   version = "1.13.6.2"
   sha_sum = "946e1958273032db43833982e2cec0766154a9b5cb8e67868944113208ff2942"
@@ -12,27 +13,42 @@ class Openresty < Formula
     end
   end
 
-  depends_on "pcre"
-  depends_on "openssl"
+  head do
+    url "https://openresty.org/download/openresty-#{version}.tar.gz"
+    sha256 sha_sum
+
+    resource "openresty-patches" do
+      url "https://github.com/Kong/openresty-patches.git", :using => :git, :shallow => false
+    end
+  end
 
   option "with-debug", "Compile with support for debug logging but without proper gdb debugging symbols"
 
+  depends_on "openssl@1.1"
+  depends_on "pcre"
+
   def install
+   openssl_prefix = Formula["openssl@1.1"].prefix
+   pcre_prefix = Formula["pcre"].prefix
+
     resource("openresty-patches").stage do
       Dir["#{pwd}/patches/#{version}/*.patch"].each do |f|
-        system "cd", buildpath/"bundle", "&&", "patch", "-p1", "<", f
+        cd buildpath/"bundle" do
+          system "patch -p1 < #{f}"
+        end
       end
     end
 
     args = [
       "--prefix=#{prefix}",
-      "--with-ipv6",
       "--with-pcre-jit",
       "--with-http_ssl_module",
       "--with-http_realip_module",
       "--with-http_stub_status_module",
-      "--with-cc-opt=-I#{HOMEBREW_PREFIX}/include,#{HOMEBREW_PREFIX}/opt/openssl/include",
-      "--with-ld-opt=-L#{HOMEBREW_PREFIX}/lib,#{HOMEBREW_PREFIX}/opt/openssl/lib",
+      "--with-http_v2_module",
+      "--with-stream_ssl_preread_module",
+      "--with-cc-opt=-I#{HOMEBREW_PREFIX}/include,#{openssl_prefix}/include,#{pcre_prefix}/include",
+      "--with-ld-opt=-L#{HOMEBREW_PREFIX}/lib,#{openssl_prefix}/lib,#{pcre_prefix}/lib",
       "-j#{ENV.make_jobs}"
     ]
 


### PR DESCRIPTION
### Summary

Preparations for `1.0.0` release. Includes `openssl` bump from `1.0.x` to `1.1.x` and adds the missing Nginx modules.