### PR TITLE
chore(*) bump kong to 1.0.1

### DIFF
--- a/Formula/kong.rb
+++ b/Formula/kong.rb
@@ -3,8 +3,8 @@ class Kong < Formula
   homepage "https://docs.konghq.com"
 
   stable do
-    url "https://bintray.com/kong/kong-community-edition-src/download_file?file_path=dists%2Fkong-community-edition-1.0.0.tar.gz"
-    sha256 "34be0f85dfe0cd058ebfe37ae0168f516e6fe68bdfd4a3a113ac28c927efe33f"
+    url "https://bintray.com/kong/kong-community-edition-src/download_file?file_path=dists%2Fkong-community-edition-1.0.1.tar.gz"
+    sha256 "c4c1264302c7210d28ba1576d1250cbd1ad533ba84caf3a6e587edf63d87b8fa"
   end
 
   head do

--- a/Formula/openresty.rb
+++ b/Formula/openresty.rb
@@ -32,7 +32,7 @@ class Openresty < Formula
    pcre_prefix = Formula["pcre"].prefix
 
     resource("openresty-patches").stage do
-      Dir["#{pwd}/patches/#{version}/*.patch"].each do |f|
+      Dir["#{pwd}/patches/#{version}/*.patch"].sort.each do |f|
         cd buildpath/"bundle" do
           system "patch -p1 < #{f}"
         end


### PR DESCRIPTION
### Summary

Bump Kong from `1.0.0` to `1.0.1`.

Also contains another patch to `openresty`formula to sort the patches before applying them (not sure if that fixes any problems, but there are issues like #85 reported to which it may or may not have effect).