### PR TITLE
fix(openresty) use kong-upgrade-tools to get the latest openresty patches

### DIFF
--- a/Formula/openresty.rb
+++ b/Formula/openresty.rb
@@ -2,17 +2,20 @@ class Openresty < Formula
   desc "Scalable Web Platform by Extending Nginx with Lua"
   homepage "https://openresty.org/"
   version "1.15.8.2"
-  kong_ngx_build_version = "0.0.8"
-  kong_ngx_build_sha_sum = "0320ddf31b93141f050c1cb3e0bb9ff03f4dbfd5e52433cd0ac2d60e25642cc0"
+  kong_build_tools_version = "3.1.3"
+  kong_build_tools_sha_sum = "870af27cccbf2dc277c66be7d37c58fb08fe73587c4ffcb3450f4d24a56302a6"
 
+  # brew install kong/kong/openresty
   stable do
-    url "https://raw.githubusercontent.com/Kong/openresty-build-tools/#{kong_ngx_build_version}/kong-ngx-build"
-    sha256 kong_ngx_build_sha_sum
+    url "https://github.com/Kong/kong-build-tools/archive/#{kong_build_tools_version}.zip"
+    sha256 kong_build_tools_sha_sum
   end
 
+  # brew install --HEAD kong/kong/openresty
   head do
-    url "https://raw.githubusercontent.com/Kong/openresty-build-tools/#{kong_ngx_build_version}/kong-ngx-build"
-    sha256 kong_ngx_build_sha_sum
+    url "https://github.com/Kong/kong-build-tools/archive/master.zip"
+    # No sha, since master is expected to change more frequently than this formula.
+    # Will generate a warning about missing SHA while installing. That is expected and ok.
   end
 
   option "with-debug", "Compile with support for debug logging but without proper gdb debugging symbols"
@@ -22,7 +25,6 @@ class Openresty < Formula
   conflicts_with "kong/kong/luarocks", :because => "We switched over to a new build method and LuaRocks no longer needs to be installed separately. Please remove it with \"brew remove kong/kong/luarocks\"."
 
   def install
-    chmod 0755, "#{pwd}/kong-ngx-build"
 
     # LuaJIT build is crashing in macOS Catalina. The defaults
     # for stack checks changed (they are on by default when the
@@ -32,9 +34,15 @@ class Openresty < Formula
     # https://forums.developer.apple.com/thread/121887
     ENV.append_to_cflags "-fno-stack-check" if DevelopmentTools.clang_build_version >= 1010
 
+    # When using `brew install --HEAD ...` the version attribute
+    # contains "HEAD", which is not understood by kong-ngx-build.
+    # So detect that case and use the version set at the top
+    # of this file (e.g. "1.15.8.2")
+    openresty_version = version.head? ? self.class.version : version
+
     args = [
       "--prefix #{prefix}",
-      "--openresty #{version}",
+      "--openresty #{openresty_version}",
       "--openssl 1.1.1d",
       "--luarocks 3.2.1",
       "-j #{ENV.make_jobs}"
@@ -47,6 +55,7 @@ class Openresty < Formula
       opoo "OpenResty and dependencies will be built --with-debug option, but without debugging symbols. For debugging symbols you have to compile it by hand."
     end
 
+    Dir.chdir('openresty-build-tools')
     system "./kong-ngx-build", *args
 
     bin.install_symlink "#{prefix}/openresty/nginx/sbin/nginx"


### PR DESCRIPTION
This is done in order to get the latest openresty patches.