### PR TITLE
fix(formula) don't use devel, point head to master

### DIFF
--- a/Formula/kong.rb
+++ b/Formula/kong.rb
@@ -10,10 +10,6 @@ class Kong < Formula
     sha256 "a1e4236119c4e13f27baf099e4be6236fc9aa947f5eaeb73bc77d17c21f5f305"
   end
 
-  #devel do
-  #  url "https://github.com/Kong/kong.git", :tag => "2.1.0-rc.1"
-  #end
-
   head do
     url "https://github.com/Kong/kong.git", :branch => "next"
   end

--- a/Formula/kong.rb
+++ b/Formula/kong.rb
@@ -11,7 +11,7 @@ class Kong < Formula
   end
 
   head do
-    url "https://github.com/Kong/kong.git", :branch => "next"
+    url "https://github.com/Kong/kong.git", :branch => "master"
   end
 
   depends_on "libyaml"


### PR DESCRIPTION
* `devel` is deprecated. Remove comment. Fixes #144
* point `head` to `master`. There is no `next` any more in the kong repo