### PR TITLE
fix(formula) set libyaml inc and lib directory for building

### DIFF
--- a/Formula/kong.rb
+++ b/Formula/kong.rb
@@ -25,14 +25,16 @@ class Kong < Formula
     luarocks_prefix = openresty_prefix + "luarocks"
     openssl_prefix = openresty_prefix + "openssl"
 
-    ENV["YAML_LIBDIR"] = Formula["libyaml"].opt_lib
-    ENV["YAML_INCDIR"] = Formula["libyaml"].opt_include
+    yaml_libdir = Formula["libyaml"].opt_lib
+    yaml_incdir = Formula["libyaml"].opt_include
 
     system "#{luarocks_prefix}/bin/luarocks",
            "--tree=#{prefix}",
            "make",
            "CRYPTO_DIR=#{openssl_prefix}",
-           "OPENSSL_DIR=#{openssl_prefix}"
+           "OPENSSL_DIR=#{openssl_prefix}",
+           "YAML_LIBDIR=#{yaml_libdir}",
+           "YAML_INCDIR=#{yaml_incdir}"
 
     bin.install "bin/kong"
   end

--- a/Formula/kong.rb
+++ b/Formula/kong.rb
@@ -25,6 +25,9 @@ class Kong < Formula
     luarocks_prefix = openresty_prefix + "luarocks"
     openssl_prefix = openresty_prefix + "openssl"
 
+    ENV["YAML_LIBDIR"] = Formula["libyaml"].opt_lib
+    ENV["YAML_INCDIR"] = Formula["libyaml"].opt_include
+
     system "#{luarocks_prefix}/bin/luarocks",
            "--tree=#{prefix}",
            "make",


### PR DESCRIPTION
Homebrew uses a different prefix `/opt/homebrew` for all the stuff on Mac with Apple M1,
this patch set YAML_LIBDIR and YAML_INCDIR dynamically based on installation path of libyaml.

Fix #174