### PR TITLE
fix(formula) sha for kong-build-tools used for openresty 1.21.4.1

### DIFF
--- a/Formula/openresty@1.21.4.1.rb
+++ b/Formula/openresty@1.21.4.1.rb
@@ -2,7 +2,7 @@ class OpenrestyAT12141 < Formula
   desc "Scalable Web Platform by Extending Nginx with Lua"
   homepage "https://openresty.org/"
   KONG_BUILD_TOOLS_VERSION = "4.33.22".freeze
-  KONG_BUILD_TOOLS_SHA_SUM = "848452e07cc5d4bff73f3d4c0ac12dcb63ede89029b5e9dec5eab1fe28fbe5c8".freeze
+  KONG_BUILD_TOOLS_SHA_SUM = "9397eb077960af5205f31b5a85025bc5262aee47054b4a797e569553ba3d8371".freeze
   OPENRESTY_VERSION = "1.21.4.1".freeze
   OPENSSL_VERSION = "1.1.1q".freeze
   LUAROCKS_VERSION = "3.9.1".freeze

--- a/Formula/openresty@1.21.4.1.rb
+++ b/Formula/openresty@1.21.4.1.rb
@@ -20,8 +20,8 @@ class OpenrestyAT12141 < Formula
 
   option "with-debug", "Compile with support for debug logging but without proper gdb debugging symbols"
 
-  depends_on "coreutils"
   depends_on "rust" => :build
+  depends_on "coreutils"
 
   def install
     # LuaJIT build is crashing in macOS Catalina. The defaults


### PR DESCRIPTION
I went to `brew install kong` today and ran into an issue where `kong-build-tools-4.33.22.tar.gz` is computing to a different sum than the one that is specified. I confirmed directly downloading the archive from github and running `sha256sum` on it.