### PR TITLE
fix(formula) remove comment from diff

### DIFF
--- a/Formula/kong.rb
+++ b/Formula/kong.rb
@@ -103,12 +103,7 @@ diff --git a/bin/kong b/bin/kong
 --- a/bin/kong
 +++ b/bin/kong
 @@ -4,6 +4,7 @@ setmetatable(_G, nil)
-#
-# patch bin/kong's LUA_PATH & LUA_CPATH with HOMEBREW_PREFIX (both intel & arm)
-# homebrew substitutes "HOMEBREW_PREFIX" when patching:
-#   https://docs.brew.sh/Formula-Cookbook#patches
-#
- 
+
  pcall(require, "luarocks.loader")
  
 -package.path = (os.getenv("KONG_LUA_PATH_OVERRIDE") or "") .. "./?.lua;./?/init.lua;" .. package.path


### PR DESCRIPTION
The diff comment makes the default `patch` fail on my (intel) mac.

With comment, patch fails:
```
∴ brew install kong/kong/kong
==> Installing kong from kong/kong
==> Installing dependencies for kong/kong/kong: kong/kong/openresty@1.21.4.1
==> Installing kong/kong/kong dependency: kong/kong/openresty@1.21.4.1
/usr/local/Homebrew/Library/Taps/kong/homebrew-kong/Formula/openresty@1.21.4.1.rb:58: warning: conflicting chdir during another chdir block
==> ./kong-ngx-build --prefix /usr/local/Cellar/openresty@1.21.4.1/1.21.4.1 --openresty 1.21.4.1 --openssl 1.1.1q --luarocks 3.9.1 --pcre 8.45 --ssl-provider openssl --atc-router 1.0.1 --resty-events 0.1.3 --resty-lmdb 1.0.0 --resty-web
/usr/local/Cellar/openresty@1.21.4.1/1.21.4.1: 561 files, 19MB, built in 4 minutes 38 seconds
==> Installing kong/kong/kong
==> Patching
Error: Failure while executing; `patch -g 0 -f -p1` exited with 2. Here's the output:
patching file 'bin/kong'
```

Without comment, patch succeeds:
```
∴ brew install -f Formula/kong.rb
Error: Failed to load cask: Formula/kong.rb
Cask 'kong' is unreadable: wrong constant name #<Class:0x00007fad5e906bf0>
Warning: Treating Formula/kong.rb as a formula.
==> Fetching kong
==> Downloading https://download.konghq.com/gateway-src/kong-3.1.1.tar.gz
Already downloaded: /Users/kikito/Library/Caches/Homebrew/downloads/24f9c15fcaa7dc824f8f88da62583c91f053625d4f80d25158cc18fee2fb56f9--kong-3.1.1.tar.gz
==> Patching
==> /usr/local/opt/openresty@1.21.4.1/luarocks/bin/luarocks ...
```

In case it helps, I am using the default apple-provided patch:
```
∴ patch -v
patch 2.0-12u11-Apple
```

Fixes #209
