### PR TITLE
Release 3.2.2 and Deprecate Homebrew

### DIFF
--- a/Formula/kong.rb
+++ b/Formula/kong.rb
@@ -5,11 +5,11 @@ class Kong < Formula
   homepage "https://docs.konghq.com"
   license "Apache-2.0"
 
-  KONG_VERSION = "3.2.1".freeze
+  KONG_VERSION = "3.2.2".freeze
 
   stable do
     url "https://github.com/Kong/kong/archive/refs/tags/#{KONG_VERSION}.tar.gz"
-    sha256 "f1583cd7ae1c8e29daa6008b2ea493c432b918d0cf3faf918891eeb314ac1499"
+    sha256 "bcd85a75c5c3cbde64dbc5d11992c85ae2d934cd7c1e3bf409ec55dd61d119c9"
   end
 
   head do

--- a/Formula/kong.rb
+++ b/Formula/kong.rb
@@ -4,6 +4,7 @@ class Kong < Formula
   desc "Open source Microservices and API Gateway"
   homepage "https://docs.konghq.com"
   license "Apache-2.0"
+  deprecate! date: "2023-03-30", because: "homebrew kong has been deprecated, please use docker instead: https://registry.hub.docker.com/_/kong/"
 
   KONG_VERSION = "3.2.2".freeze
 
@@ -172,11 +173,11 @@ diff --git a/bin/kong b/bin/kong
 @@ -4,6 +4,7 @@ setmetatable(_G, nil)
 
  pcall(require, "luarocks.loader")
- 
+
 -package.path = (os.getenv("KONG_LUA_PATH_OVERRIDE") or "") .. "./?.lua;./?/init.lua;" .. package.path
 +package.cpath = (os.getenv("KONG_LUA_CPATH_OVERRIDE") or "") .. "HOMEBREW_PREFIX/lib/lua/5.1/?.so;" .. package.cpath
 +package.path = (os.getenv("KONG_LUA_PATH_OVERRIDE") or "") .. "./?.lua;./?/init.lua;" .. "HOMEBREW_PREFIX/share/lua/5.1/?.lua;HOMEBREW_PREFIX/share/lua/5.1/?/init.lua;" .. package.path
- 
+
  require("kong.cmd.init")(arg)
 diff --git a/kong/templates/kong_defaults.lua b/kong/templates/kong_defaults.lua
 --- a/kong/templates/kong_defaults.lua
@@ -196,7 +197,7 @@ diff --git a/kong/templates/kong_defaults.lua b/kong/templates/kong_defaults.lua
 -lua_package_cpath = NONE
 +lua_package_path = ./?.lua;./?/init.lua;HOMEBREW_PREFIX/share/lua/5.1/?.lua;HOMEBREW_PREFIX/share/lua/5.1/?/init.lua;;
 +lua_package_cpath = HOMEBREW_PREFIX/lib/lua/5.1/?.so;;
- 
+
  role = traditional
  kic = off
 diff -r -u a/kong/cmd/prepare.lua b/kong/cmd/prepare.lua

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# DEPRECATED
+
+[![No Maintenance Intended](http://unmaintained.tech/badge.svg)](http://unmaintained.tech/)
+
+The Kong homebrew formula is no longer supported, please consider using Docker instead for local development:
+
+https://hub.docker.com/_/kong
+
 # Homebrew Kong Tap
 
 Homebrew tap for [Kong] :beer:


### PR DESCRIPTION
- disable homebrew formula in favor of Docker

After this merged is done, we should:

[ ] Add GitHub topics: deprecated, obselete, and archived

KAG-1069
